### PR TITLE
Update readme with missing dependency

### DIFF
--- a/packages/gatsby-plugin-use-query-params/README.md
+++ b/packages/gatsby-plugin-use-query-params/README.md
@@ -16,7 +16,7 @@ Drop in support for [`use-query-params`](https://www.npmjs.com/package/use-query
 ## Installation
 
 ```
-npm install use-query-params gatsby-plugin-use-query-params
+npm install use-query-params query-string gatsby-plugin-use-query-params
 ```
 
 ## Usage


### PR DESCRIPTION
The current README doesn't include a missing dependency with is needed by [use-query-param](https://github.com/pbeshai/use-query-params#installation). This PR includes it to make it even simpler to use this package. 

And thanks for it!