### PR TITLE
Update README.md / Fix outdated list of packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,4 @@
 
 This is the central repository for all my Gatsby packages.
 
-Available packages:
-
-- [`gatsby-plugin-firebase`](https://www.npmjs.com/package/gatsby-plugin-firebase)
-- [`gatsby-plugin-prefix`](https://www.npmjs.com/package/gatsby-plugin-prefix)
+Available packages: [see `/packages](/packages)


### PR DESCRIPTION
The list was out of date. It now links to the `/packages` folder.