### PR TITLE
feat(gatsby-plugin-use-query-params): use-query-params support to v2

### DIFF
--- a/packages/gatsby-plugin-use-query-params/package.json
+++ b/packages/gatsby-plugin-use-query-params/package.json
@@ -19,6 +19,6 @@
     "gatsby": ">=2.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "use-query-params": ">=0.4.3"
+    "use-query-params": ">=2.0.0"
   }
 }

--- a/packages/gatsby-plugin-use-query-params/root.js
+++ b/packages/gatsby-plugin-use-query-params/root.js
@@ -1,13 +1,8 @@
 import React from "react";
-import { Location, globalHistory } from "@reach/router";
+
 import { QueryParamProvider } from "use-query-params";
+import { ReachAdapter } from "use-query-params/adapters/reach";
 
 export default ({ children }) => (
-  <Location>
-    {({ location }) => (
-      <QueryParamProvider location={location} reachHistory={globalHistory}>
-        {children}
-      </QueryParamProvider>
-    )}
-  </Location>
+  <QueryParamProvider adapter={ReachAdapter}>{children}</QueryParamProvider>
 );


### PR DESCRIPTION
According to https://github.com/alexluong/gatsby-packages/issues/41 and https://github.com/alexluong/gatsby-packages/issues/46

Version with gatsby 5 support and with use-query-params 2